### PR TITLE
Fix error message, missing store name or date

### DIFF
--- a/flutter_kubera/lib/src/services/flask_service.dart
+++ b/flutter_kubera/lib/src/services/flask_service.dart
@@ -60,7 +60,7 @@ class FlaskService {
 
   // This api will call gpt to get generic matches to be verified by the user
   Future<ScannedReceipt> mapReceipt(ScannedReceipt receipt) async {
-    try {
+    
         final response = await http.post(
         Uri.parse('$baseUrl/map_receipt'),
         headers: {'Content-Type': 'application/json'},
@@ -71,15 +71,15 @@ class FlaskService {
         final jsonResponse = jsonDecode(response.body);
         final receiptJson = jsonResponse['receipt'];
         return ScannedReceipt.fromJson(receiptJson);
+      }else if (response.statusCode == 400) {
+        final jsonResponse = jsonDecode(response.body);
+        final errorMessage = jsonResponse['message'];
+        throw Exception(errorMessage);
       }
       else {
         throw Exception('Failed to map receipt: ${response.statusCode}');
       }
 
-    }
-    catch (e) {
-      throw Exception('Failed to map receipt: $e');
-    }
   }
 
   // This api will post the receipt to mongo after full confirmation (product name and generic name)

--- a/flutter_kubera/lib/src/ui/tabs/scan/product_name_confirmation.dart
+++ b/flutter_kubera/lib/src/ui/tabs/scan/product_name_confirmation.dart
@@ -76,7 +76,8 @@ class _ProductNameConfirmationScreenState extends State<ProductNameConfirmationS
       showDialog(
         context: context,
         builder: (BuildContext context) {
-          return ErrorDialog(message: 'Failed to post receipt: $e');
+          String userMessage = e.toString().replaceAll("Exception: ", "");
+          return ErrorDialog(message: userMessage);
         },
       );
     } finally {


### PR DESCRIPTION
- Catch 400 error from backend when the user tries to proceed to view receipt product mappings with a missing date or store name field
- Remove extraneous try-catch blocks from flask service call, exception is now caught and handled on the name confirmation page in the error dialog